### PR TITLE
Rename KeyswitchEvent & KeyswitchState structures

### DIFF
--- a/src/unshifter/Unshifter.cpp
+++ b/src/unshifter/Unshifter.cpp
@@ -9,10 +9,10 @@
 #include KALEIDOGLYPH_KEYADDR_H
 #include <kaleidoglyph/Key.h>
 #include <kaleidoglyph/Plugin.h>
-#include <kaleidoglyph/KeyswitchState.h>
+#include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/KeyArray.h>
 #include <kaleidoglyph/KeyswitchEvent.h>
-#include <kaleidoglyph/KeyswitchState.h>
+#include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/hid/Report.h>
 
 

--- a/src/unshifter/Unshifter.cpp
+++ b/src/unshifter/Unshifter.cpp
@@ -11,7 +11,7 @@
 #include <kaleidoglyph/Plugin.h>
 #include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/KeyArray.h>
-#include <kaleidoglyph/KeyswitchEvent.h>
+#include <kaleidoglyph/KeyEvent.h>
 #include <kaleidoglyph/KeyState.h>
 #include <kaleidoglyph/hid/Report.h>
 
@@ -37,7 +37,7 @@ bool isRealShift(Key key) {
 }
 
 // Event handler
-bool Plugin::keyswitchEventHook(KeyswitchEvent& event,
+bool Plugin::keyswitchEventHook(KeyEvent& event,
                                 kaleidoglyph::Plugin*& caller) {
   // If Unkeys has already processed this event:
   if (checkCaller(caller))
@@ -77,7 +77,7 @@ bool Plugin::preReportHook(hid::keyboard::Report& keyboard_report) {
 
 
 // Update the count of "true" shift keys held
-void Plugin::postReportHook(KeyswitchEvent event) {
+void Plugin::postReportHook(KeyEvent event) {
   // I'm a bit concerned about the possibility of the count getting out of sync here, but
   // I'm going to trust it for now, and see how it plays out. If it doesn't work, we can
   // drop this hook function and just iterate through the array in the preReportHook to

--- a/src/unshifter/Unshifter.h
+++ b/src/unshifter/Unshifter.h
@@ -33,12 +33,12 @@ class Plugin : public kaleidoglyph::Plugin {
   Plugin(const Unkey* const unkeys, const byte unkey_count)
       : unkeys_(unkeys), unkey_count_(unkey_count) {}
 
-  bool keyswitchEventHook(KeyswitchEvent& event,
+  bool keyswitchEventHook(KeyEvent& event,
                           kaleidoglyph::Plugin*& caller) override;
 
   bool preReportHook(hid::keyboard::Report& keyboard_report) override;
 
-  void postReportHook(KeyswitchEvent event) override;
+  void postReportHook(KeyEvent event) override;
 
  private:
   // An array of Unkey objects


### PR DESCRIPTION
I'm trying to make a distinction between events that are physical-only (Keyswitch*) and the more general events that can be software-only (Key*), in advance of changing the hooks available in the event handler loop.

See gedankenlab/Kaleidoglyph-Core#14